### PR TITLE
Update version in install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ And declare it as a dependency:
 defp deps do
   [
     # ...
-    {:metrix, "~> 0.1.0"}
+    {:metrix, "~> 0.2.0"}
   ]
 end
 ```


### PR DESCRIPTION
I was wondering why I couldn't use metadata in my calls... Guess what, I had installed the wrong version :)
