### PR TITLE
Allow `measure` to take custom value

### DIFF
--- a/lib/metrix.ex
+++ b/lib/metrix.ex
@@ -46,20 +46,27 @@ defmodule Metrix do
     metadata
   end
 
-  def measure(metric, fun), do: measure(%{}, metric, fun)
-  def measure(metadata, metric, fun) do
-
+  def measure(metric, fun) when is_function(fun), do: measure(%{}, metric, fun)
+  def measure(metric, value) when is_binary(value), do: measure(%{}, metric, value)
+  def measure(metadata, metric, fun) when is_function(fun) do
     {service_us, ret_value} = cond do
       is_function(fun, 0) -> :timer.tc(fun)
       is_function(fun, 1) -> :timer.tc(fun, [metadata])
     end
 
     metadata
-    |> add(:"measure##{metric}", "#{service_us / 1000}ms")
-    |> log
+    |> measure(metric, "#{service_us / 1000}ms")
 
     ret_value
   end
+  def measure(metadata, metric, value) when is_binary(value) do
+    metadata
+    |> add(:"measure##{metric}", value)
+    |> log
+
+    metadata
+  end
+
 
   def log(values) do
     values

--- a/test/metrix_test.exs
+++ b/test/metrix_test.exs
@@ -73,6 +73,11 @@ defmodule MetrixTest do
     assert output |> String.contains?("meta=data")
   end
 
+  test "measure with explicit value" do
+    output = line(fn -> Metrix.measure("event.name", "2.43msms") end)
+    assert matches_measure?(output), "Unexpected output format \"#{output}\""
+  end
+
   test "context" do
     for context <- [%{"global" => "context"}, [global: "context"]] do
       Metrix.add_context context


### PR DESCRIPTION
In some cases[1] the time duration has to be manually calculated and written as metrics. Wrapping the block of code with a function is not feasible here.

[1] such as writing a Plug.Conn, https://github.com/hahuang65/beaker/blob/master/lib/beaker/integrations/phoenix.ex#L27
