### PR TITLE
Use Logger instead of IO.puts for output

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,11 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+config :logger, :console,
+  level: :info,
+  format: "$message\n",
+  colors: [enabled: false]
+
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,

--- a/lib/metrix.ex
+++ b/lib/metrix.ex
@@ -70,5 +70,5 @@ defmodule Metrix do
 
   defp add(dict, key, value), do: dict |> Dict.put(key, value)
 
-  defp write(output), do: output |> IO.puts
+  defp write(output), do: output |> Logger.info
 end

--- a/test/metrix_test.exs
+++ b/test/metrix_test.exs
@@ -1,7 +1,7 @@
 defmodule MetrixTest do
 
   use ExUnit.Case
-  import ExUnit.CaptureIO
+  import ExUnit.CaptureLog
 
   setup do
     on_exit fn -> Metrix.clear_context end
@@ -97,7 +97,7 @@ defmodule MetrixTest do
     assert output |> String.contains?("event.name=1")
   end
 
-  defp line(fun), do: capture_io(fun) |> String.strip
+  defp line(fun), do: capture_log(fun) |> String.strip
 
   defp matches_measure?(output) do
     Regex.match?(~r/measure#event.name=[0-9]+\.+[0-9]+ms/u, output)


### PR DESCRIPTION
Using `IO.puts` works fine, but `Logger` for output is a better choice since it allows more control over the output. e.g. `capture_log` in tests.

Paired with @davidsantoso

Fixes #5 
