### PR TITLE
Relax Elixir version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Metrix.Mixfile do
     [app: :metrix,
      version: "0.3.0",
      description: description,
-     elixir: "~> 1.1.0",
+     elixir: ">= 1.1.0",
      deps: deps,
      package: package,
      source_url: "https://github.com/rwdaigle/metrix"]


### PR DESCRIPTION
Gives a warning with 1.3.0.
