### PR TITLE
Add config support to initialize the context

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,13 @@ config :logger, :console,
   colors: [enabled: false]
  ```
 
+Metrix allows its initial context to be configured, which must be a map:
+
+```elixir
+config :metrix,
+  context: %{"source", "my-app"}
+```
+
 ## Heroku & Librato
 
 Librato is my preferred choice for metrics visualization and long-term storage. It also plays very well with apps deployed to Heroku. Follow these instructions to get your Heroku app's Metrix log output streaming to Librato for processing.

--- a/config/config.exs
+++ b/config/config.exs
@@ -21,4 +21,5 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-#     import_config "#{Mix.env}.exs"
+
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :metrix,
+  context: %{"test_key" => "test_value"}

--- a/lib/context.ex
+++ b/lib/context.ex
@@ -3,7 +3,7 @@ defmodule Metrix.Context do
   Starts a new context.
   """
   def start_link do
-    Agent.start_link(fn -> %{} end, name: __MODULE__)
+    Agent.start_link(fn -> config() end, name: __MODULE__)
   end
 
   @doc """
@@ -25,5 +25,14 @@ defmodule Metrix.Context do
   """
   def clear do
     Agent.update(__MODULE__, fn _metadata -> %{} end)
+  end
+
+  # Read any configuration values
+  defp config do
+    case Application.get_env(:metrix, :context) do
+      nil -> %{}
+      context ->
+        context
+    end
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"ex_doc": {:hex, :ex_doc, "0.7.3"},
-  "logfmt": {:hex, :logfmt, "3.0.2"},
+%{"ex_doc": {:hex, :ex_doc, "0.7.3", "8f52bfbfcbc0206dd08dd94aae86a3fd5330ba2f37c73cfea2918ed4c96d1769", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "logfmt": {:hex, :logfmt, "3.0.2", "8d1266d8ea4e35cb476952723a9c91e0684caa233bf51a6e58187598be50da60", [:mix], []},
   "logfmt-elixir": {:git, "https://github.com/jclem/logfmt-elixir.git", "9a961a5d82caabd0fcb400bffe4249e3129ca227", []}}

--- a/test/context_test.exs
+++ b/test/context_test.exs
@@ -1,0 +1,9 @@
+defmodule ContextTest do
+  use ExUnit.Case
+
+  @moduletag :config
+
+  test "configured context" do
+    assert Metrix.get_context == %{"test_key" => "test_value"}
+  end
+end

--- a/test/metrix_test.exs
+++ b/test/metrix_test.exs
@@ -4,7 +4,7 @@ defmodule MetrixTest do
   import ExUnit.CaptureLog
 
   setup do
-    on_exit fn -> Metrix.clear_context end
+    Metrix.clear_context
   end
 
   test "basic count" do
@@ -34,6 +34,7 @@ defmodule MetrixTest do
   end
 
   test "sample" do
+    Metrix.clear_context
     assert line(fn -> Metrix.sample "event.name", "13.4mb" end) == "sample#event.name=13.4mb"
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,7 @@
 ExUnit.start()
 
+ExUnit.configure exclude: [:config]
+
 # Streamline logger output to just the message for easier testing
 Logger.configure_backend :console,
   level: :info,


### PR DESCRIPTION
Added support to configure the context using `:metrix` and `:context`.

E.g.

```
config :metrix,
  context: %{"key" => "value"}
```

The tests in `metrix_test.exs` clear the context before each test. It used to clear it after, but clearing it before removes the values added to `test.exs`, which are used for testing that configuration actually takes effect.

There's a new test, `context_test.exs` with the module tag `:config`, for testing the configuration.

```
mix test --only config
```
