### PR TITLE
Support full formatting of the metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,35 @@ config :metrix,
   context: %{"source" => "my-app"}
 ```
 
+The format of each metric can also be customized through formats and parameters:
+
+```Elixir
+config :metrix,
+  count_format: "$count#$prefix.$metric",
+  measure_format: "$measure#$prefix.$metric",
+  sample_format: "$sample#$prefix.$metric",
+  parameters: %{
+    :prefix => "my-prefix",
+    :count => "count-it",
+    :measure => "measure-it",
+    :sample => "sample-it",
+  }
+```
+
+Given the above config, `Metrix.count "event.name"` would yield:
+
+```
+count-it#my-prefix.event.name=1
+```
+
+The default formats are:
+
+* count: count#$metric
+* measure: measure#$metric
+* sample: sample#$metric
+
+Where `$metric` is the name of the metric passed in.
+
 Metrix writes to `Logger.info`. To adjust the output target, set the logger configuration in `config.exs`. For instance, to write to `stdout` (the Elixir default) with no timestamp line info, do:
 
 ```elixir

--- a/lib/context.ex
+++ b/lib/context.ex
@@ -18,7 +18,7 @@ defmodule Metrix.Context do
   Adds the `metadata` to the context
   """
   def put(metadata) do
-    Agent.update(__MODULE__, &Dict.merge(&1, metadata))
+    Agent.update(__MODULE__, &Enum.into(metadata, &1))
   end
 
   @doc """

--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -1,0 +1,167 @@
+defmodule Metrix.Formatter do
+  @moduledoc """
+  Provide formatting for metrics.
+  
+  This only impacts the `type#metric` portion of the output.
+
+  The formatting can be configured with formats and parameters:
+
+  ```
+  config :metrix,
+    count_format: "count#$prefix$metric",
+    measure_format: "measure#$prefix$metric",
+    sample_format: "sample#$prefix$metric",
+    parameters: %{:prefix => "my-prefix."}
+  ```
+
+  The default formats are:
+
+  * count: count#$metric
+  * measure: measure#$metric
+  * sample: sample#$metric
+
+  Where `$metric` is the name of the metric passed in.
+  """
+  
+  # Matches all placeholders: `$term`
+  @placeholder_pattern ~r/\$(\w+)/
+
+  def start_link() do
+    Agent.start_link(fn -> init end, name: __MODULE__)
+  end
+
+  def format_count(metric) do
+    format(count_format, metric)
+  end
+
+  def format_measure(metric) do
+    format(measure_format, metric)
+  end
+
+  def format_sample(metric) do
+    format(sample_format, metric)
+  end
+  
+  def count_format(format_string) do
+    Agent.update(__MODULE__, &Map.put(&1, :count_format, format_string))
+  end
+  
+  def measure_format(format_string) do
+    Agent.update(__MODULE__, &Map.put(&1, :measure_format, format_string))
+  end
+  
+  def sample_format(format_string) do
+    Agent.update(__MODULE__, &Map.put(&1, :sample_format, format_string))
+  end
+
+  def add_parameter(name, value) when is_atom(name), do: add_parameter(Atom.to_string(name), value)
+  def add_parameter(name, value) do
+    Agent.update(__MODULE__, fn(map) ->
+      map
+      |> Map.update!(:parameters, &Map.put(&1, name, value))
+    end)
+  end
+
+  def get_parameter(name) when is_atom(name), do: get_parameter(Atom.to_string(name))
+  def get_parameter(name) do
+    Agent.get(__MODULE__, fn(map) ->
+      map
+      |> Map.get(:parameters)
+      |> Map.get(name)
+    end)
+  end
+  
+  def remove_parameter(name) when is_atom(name), do: remove_parameter(Atom.to_string(name))
+  def remove_parameter(name) do
+    Agent.update(__MODULE__, fn(map) ->
+      map
+      |> Map.update!(:parameters, &Map.delete(&1, name))
+    end)
+  end
+
+  def reset do
+    Agent.update(__MODULE__, fn(_map) -> init end)
+  end
+
+  defp init do
+    %{}
+    |> capture_count_format
+    |> capture_measure_format
+    |> capture_sample_format
+    |> capture_parameters
+  end
+
+  defp count_format do
+    Agent.get(__MODULE__, &Map.get(&1, :count_format))
+  end
+
+  defp measure_format do
+    Agent.get(__MODULE__, &Map.get(&1, :measure_format))
+  end
+
+  defp sample_format do
+    Agent.get(__MODULE__, &Map.get(&1, :sample_format))
+  end
+
+  defp format(format_string, metric) do
+    parameters
+    |> Map.put("metric", metric)
+    |> format_with_parameters(format_string)
+    |> String.to_atom
+  end
+
+  defp format_with_parameters(parameters, format_string) do
+    Regex.scan(@placeholder_pattern, format_string)
+    |> Enum.reduce(format_string, fn(term, format_string) ->
+      [placeholder_pattern, parameter] = term
+      String.replace(format_string, placeholder_pattern, parameters[parameter])
+    end)
+  end
+
+  defp parameters do
+    Agent.get(__MODULE__, &Map.get(&1, :parameters))
+  end
+
+  defp capture_count_format(map) do
+    map
+    |> capture_format(:count_format, "count#$metric")
+  end
+
+  defp capture_measure_format(map) do
+    map
+    |> capture_format(:measure_format, "measure#$metric")
+  end
+
+  defp capture_sample_format(map) do
+    map
+    |> capture_format(:sample_format, "sample#$metric")
+  end
+
+  defp capture_format(map, atom, default) do
+    map
+    |> Map.merge(case Application.get_env(:metrix, atom) do
+      nil -> %{atom => default}
+      fmt -> %{atom => fmt}
+    end)
+  end
+
+  defp capture_parameters(map) do
+    Map.put(map, :parameters, capture_parameters |> normalize_parameters)
+  end
+
+  defp capture_parameters do
+    case Application.get_env(:metrix, :parameters) do
+      nil -> %{}
+      map -> map
+    end
+  end
+
+  defp normalize_parameters(parameters) do
+    Enum.reduce(parameters, %{}, fn({name, value}, map) ->
+      Map.put(map, normalize_term(name), normalize_term(value))
+    end)
+  end
+
+  def normalize_term(term) when is_atom(term), do: Atom.to_string(term)
+  def normalize_term(term), do: term
+end

--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -107,7 +107,6 @@ defmodule Metrix.Formatter do
     parameters
     |> Map.put("metric", metric)
     |> format_with_parameters(format_string)
-    |> String.to_atom
   end
 
   defp format_with_parameters(parameters, format_string) do

--- a/lib/metrix.ex
+++ b/lib/metrix.ex
@@ -51,6 +51,7 @@ defmodule Metrix do
   def count(metadata, metric), do: count(metadata, metric, 1)
   def count(metadata, metric, num) do
     metadata
+    |> Enum.into(%{})
     |> add(Formatter.format_count(metric), num)
     |> log
 
@@ -60,6 +61,7 @@ defmodule Metrix do
   def sample(metric, value), do: sample(%{}, metric, value)
   def sample(metadata, metric, value) do
     metadata
+    |> Enum.into(%{})
     |> add(Formatter.format_sample(metric), value)
     |> log
 
@@ -75,6 +77,7 @@ defmodule Metrix do
     end
 
     metadata
+    |> Enum.into(%{})
     |> add(Formatter.format_measure(metric), "#{service_us / 1000}ms")
     |> log
 
@@ -83,12 +86,12 @@ defmodule Metrix do
 
   def log(values) do
     values
-    |> Dict.merge(get_context())
+    |> Map.merge(get_context())
     |> Logfmt.encode
     |> write
   end
 
-  defp add(dict, key, value), do: dict |> Dict.put(key, value)
+  defp add(map, key, value), do: Map.put(map, key, value)
 
   defp write(output), do: output |> Logger.info
 end

--- a/lib/metrix.ex
+++ b/lib/metrix.ex
@@ -3,12 +3,14 @@ require Logger
 defmodule Metrix do
   use Application
   alias Metrix.Context
+  alias Metrix.Formatter
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
     children = [
-      worker(Metrix.Context, [initial_context()])
+      worker(Context, [initial_context()]),
+      worker(Formatter, [])
     ]
 
     opts = [strategy: :one_for_one, name: Metrix.Supervisor]
@@ -22,6 +24,11 @@ defmodule Metrix do
     end
   end
 
+  def reset do
+    clear_context
+    Formatter.reset
+  end
+
   @doc """
   Adds `metadata` to the global context, which will add the metadata values
   to all subsequent metrix output. Global context is useful for component-wide
@@ -32,12 +39,19 @@ defmodule Metrix do
   def get_context, do: Context.get
   def clear_context, do: Context.clear
 
+  def count_format(format_string), do: Formatter.count_format(format_string)
+  def measure_format(format_string), do: Formatter.measure_format(format_string)
+  def sample_format(format_string), do: Formatter.sample_format(format_string)
+  def add_parameter(name, value), do: Formatter.add_parameter(name, value)
+  def get_parameter(name), do: Formatter.get_parameter(name)
+  def remove_parameter(name), do: Formatter.remove_parameter(name)
+
   def count(metric), do: count(metric, 1)
   def count(metric, num) when is_number(num), do: count(%{}, metric, num)
   def count(metadata, metric), do: count(metadata, metric, 1)
   def count(metadata, metric, num) do
     metadata
-    |> add(:"count##{metric}", num)
+    |> add(Formatter.format_count(metric), num)
     |> log
 
     metadata
@@ -46,7 +60,7 @@ defmodule Metrix do
   def sample(metric, value), do: sample(%{}, metric, value)
   def sample(metadata, metric, value) do
     metadata
-    |> add(:"sample##{metric}", value)
+    |> add(Formatter.format_sample(metric), value)
     |> log
 
     metadata
@@ -61,7 +75,7 @@ defmodule Metrix do
     end
 
     metadata
-    |> add(:"measure##{metric}", "#{service_us / 1000}ms")
+    |> add(Formatter.format_measure(metric), "#{service_us / 1000}ms")
     |> log
 
     ret_value


### PR DESCRIPTION
Added `Metrix.Formatter` for arbitrary formatting of the metrics.

The formatting and parameters may be controlled through configuration
or at runtime.

Updated the README with examples and instructions.

Something like this seems like a far more interesting approach than the "prefix" approach. I'd be happy to incorporate any feedback.