### PR TITLE
Fix keyword list issue with global context

### DIFF
--- a/lib/metrix.ex
+++ b/lib/metrix.ex
@@ -83,8 +83,7 @@ defmodule Metrix do
   end
 
   def log(values) do
-    values
-    |> Dict.merge(get_context())
+    Dict.merge(get_context(), values)
     |> Logfmt.encode
     |> write
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "logfmt": {:hex, :logfmt, "3.2.0", "887a091adad28acc6e4d8b3d3bce177b934e7c61e7655c86946410f44aca6d84", [:mix], []},
+%{"earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "logfmt": {:hex, :logfmt, "3.2.0", "887a091adad28acc6e4d8b3d3bce177b934e7c61e7655c86946410f44aca6d84", [:mix], [], "hexpm"},
   "logfmt-elixir": {:git, "https://github.com/jclem/logfmt-elixir.git", "9a961a5d82caabd0fcb400bffe4249e3129ca227", []}}

--- a/test/metrix_test.exs
+++ b/test/metrix_test.exs
@@ -34,11 +34,31 @@ defmodule MetrixTest do
     end
   end
 
+  test "count with number and metadata and global context" do
+    Metrix.add_context %{"meta" => "data_global"}
+    for metadata <- [%{"meta" => "data"}, [meta: "data"]] do
+      output = line(fn -> Metrix.count metadata, "event.name", 23 end)
+      assert output |> String.contains?("count#event.name=23")
+      assert output |> String.contains?("meta=data")
+      line(fn -> assert Metrix.count(metadata, "event.name", 1) == metadata end)
+    end
+  end
+
   test "sample" do
     assert line(fn -> Metrix.sample "event.name", "13.4mb" end) == "sample#event.name=13.4mb"
   end
 
   test "sample with metadata" do
+    for metadata <- [%{"meta" => "data"}, [meta: "data"]] do
+      output = line(fn -> Metrix.sample metadata, "event.name", "13.4mb" end)
+      assert output |> String.contains?("sample#event.name=13.4mb")
+      assert output |> String.contains?("meta=data")
+      line(fn -> assert Metrix.sample(metadata, "event.name", "13.4mb") == metadata end)
+    end
+  end
+
+  test "sample with metadata and global context" do
+    Metrix.add_context %{"meta" => "data_global"}
     for metadata <- [%{"meta" => "data"}, [meta: "data"]] do
       output = line(fn -> Metrix.sample metadata, "event.name", "13.4mb" end)
       assert output |> String.contains?("sample#event.name=13.4mb")
@@ -74,6 +94,15 @@ defmodule MetrixTest do
     assert output |> String.contains?("meta=data")
   end
 
+  test "measure with metadata and global context" do
+    Metrix.add_context %{"meta" => "data_global"}
+    for metadata <- [%{"meta" => "data"}, [meta: "data"]] do
+      output = line(fn -> Metrix.measure metadata, "event.name", fn -> :timer.sleep(1) end end)
+      assert matches_measure?(output), "Unexpected output format \"#{output}\""
+      assert output |> String.contains?("meta=data")
+    end
+  end
+
   test "count with prefix" do
     Metrix.put_prefix("prefix-")
     assert line(fn -> Metrix.count "event.name" end) == "count#prefix-event.name=1"
@@ -89,4 +118,5 @@ defmodule MetrixTest do
     Metrix.put_prefix("prefix-")
     assert line(fn -> Metrix.sample "event.name", "13.4mb" end) == "sample#prefix-event.name=13.4mb"
   end
+
 end


### PR DESCRIPTION
Allow a keyword list to be used with the global context.  Allow metadata passed as 
a function argument to override the global context.

Resolves #14.